### PR TITLE
Remove old 'ems_id' attribute

### DIFF
--- a/lib/topological_inventory/persister/workflow.rb
+++ b/lib/topological_inventory/persister/workflow.rb
@@ -39,7 +39,7 @@ module TopologicalInventory
           :association                 => :refresh_states,
           :create_only                 => true,
           :model_class                 => RefreshState,
-          :inventory_object_attributes => %i(ems_id uuid status source_id tenant_id),
+          :inventory_object_attributes => %i(uuid status source_id tenant_id),
           :default_values              => {
             :source_id => manager.id,
             :tenant_id => manager.tenant_id,


### PR DESCRIPTION
`ems_id` is probably forgotten there from ManageIQ