### PR TITLE
Inventory refresh tracking

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -334,6 +334,26 @@ class OpenapiGenerator
         :total_parts             => {
           :type => "integer"
         },
+        :refresh_state_part_collected_at    => {
+          :type   => "string",
+          :format => "date-time"
+        },
+        :refresh_state_part_sent_at       => {
+          :type   => "string",
+          :format => "date-time"
+        },
+        :refresh_state_started_at    => {
+          :type   => "string",
+          :format => "date-time"
+        },
+        :refresh_state_sent_at       => {
+          :type   => "string",
+          :format => "date-time"
+        },
+        :ingress_api_sent_at     => {
+          :type   => "string",
+          :format => "date-time"
+        },
         :sweep_scope             => {
           :oneOf => [
             {
@@ -539,7 +559,7 @@ class OpenapiGenerator
   end
 
   GENERATOR_BLACKLIST_ATTRIBUTES = [
-    :id, :resource_timestamps, :resource_timestamps_max, :tenant_id, :source_id, :created_at, :updated_at, :last_seen_at
+    :id, :resource_timestamps, :resource_timestamps_max, :tenant_id, :source_id, :created_at, :updated_at, :last_seen_at, :refresh_state_part_id
   ].to_set.freeze
 
   GENERATOR_ALLOW_BLACKLISTED_ATTRIBUTES = {}.freeze


### PR DESCRIPTION
**Issue**: #52 

1) Links from data to RefreshStatePart moved from core: https://github.com/RedHatInsights/topological_inventory-core/pull/186 (#183)
2) Exclude relations from openapi generator
3) Saving refresh timestamps:
* refresh_state_part_collected_at
* refresh_state_part_sent_at
* refresh_state_started_at
* refresh_state_sent_at
* ingress_api_sent_at
* persister_started_at [core]
* persister_finished_at [core]

---

* [x] **depens on** https://github.com/RedHatInsights/topological_inventory-core/pull/186