### PR TITLE
Bump core to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "manageiq-loggers",    "~> 0.4.0", ">= 0.4.2"
 gem "manageiq-messaging",  "~> 0.1.2"
 gem "prometheus_exporter", "~> 0.4.5"
 
-gem "topological_inventory-core", :git => "https://github.com/RedHatInsights/topological_inventory-core", :branch => "master"
+gem "topological_inventory-core", "~> 1.0.0"
 
 group :development do
   gem "rspec-rails", "~>3.8"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-core/issues/190

Merged PRs can't affect production with incompatible code

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-core/pull/189 **[ requires RubyGems release ]**