### PR TITLE
Unique Kafka's client_ref

### DIFF
--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -98,8 +98,7 @@ module TopologicalInventory
       def default_messaging_opts
         {
           :protocol   => :Kafka,
-          :client_ref => "persister-worker",
-          :group_ref  => "persister-worker",
+          :client_ref => ENV['HOSTNAME'].presence || SecureRandom.hex(4),
           :encoding   => "json",
         }
       end


### PR DESCRIPTION
`client_ref` is consumer's unique ID, so it should be unique.
I didn't find `group_ref`, it seems redundant