### PR TITLE
Publish forwardable headers in Task.update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "manageiq-loggers",    "~> 0.4.0", ">= 0.4.2"
 gem "manageiq-messaging",  "~> 0.1.2"
 gem "prometheus_exporter", "~> 0.4.5"
 
-gem "topological_inventory-core", "~> 1.1.2"
+gem "topological_inventory-core", "~> 1.1.4"
 
 group :development do
   gem "rspec-rails", "~>3.8"

--- a/lib/topological_inventory/persister/workflow.rb
+++ b/lib/topological_inventory/persister/workflow.rb
@@ -151,13 +151,13 @@ module TopologicalInventory
         return if tasks_ic.nil?
 
         tasks_ic.updated_records.to_a.each do |payload|
-          request_id = payload.delete(:x_rh_insights_request)
+          forwardable_headers = payload.delete(:forwardable_headers)
 
           messaging_client.publish_topic(
             :service => "platform.topological-inventory.task-output-stream",
             :event   => "Task.update",
             :payload => payload,
-            :headers => {'x-rh-insights-request-id' => request_id}
+            :headers => forwardable_headers
           )
         end
       end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-persister/issues/58

Insights::API::Common::Request.current_forwardable is saved in Task instead of x-rh-insights-request-id. To be able to resend it through Kafka in persister

---

* [x] **depends on** https://github.com/RedHatInsights/topological_inventory-core/pull/197
  - **requires** RubyGems v1.1.4