### PR TITLE
Fix of rake task openapi:generate

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -56,11 +56,14 @@ class OpenapiGenerator
 
   def add_primary_reference_schema(inventory_collection)
     class_name                                                                 = inventory_collection.model_class.to_s
+    return if class_name.blank?
+
     schemas["#{inventory_collection.name.to_s.singularize.camelize}Reference"] = lazy_find(class_name, inventory_collection)
   end
 
   def add_secondary_reference_schema(inventory_collection, key)
     class_name = inventory_collection.model_class.to_s
+    return if class_name.blank?
 
     schemas["#{inventory_collection.name.to_s.singularize.camelize}Reference#{key.to_s.camelize}"] = lazy_find(class_name, inventory_collection, key)
   end
@@ -474,6 +477,7 @@ class OpenapiGenerator
 
     inventory_collections.each do |_key, inventory_collection|
       next unless savable_inventory_collection?(inventory_collection)
+      next if inventory_collection.model_class.nil?
 
       build_inventory_collection_schema(inventory_collection)
       build_schema(inventory_collection)

--- a/spec/openapi_generator_spec.rb
+++ b/spec/openapi_generator_spec.rb
@@ -1,0 +1,15 @@
+require 'rake'
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+describe "openapi_generate.rake" do
+  before do
+    Rake.application.rake_require('tasks/openapi_generate')
+    allow(File).to receive(:write).and_return(nil)
+  end
+
+  it "doesn't raise an exception" do
+    # TODO: It can work after the generator will be able to create json
+    # TODO: it's only able to update existing openapi json now
+    # expect { Rake.application["openapi:generate"].invoke }.not_to raise_exception
+  end
+end


### PR DESCRIPTION
`InventoryCollection` without model_class can't be processed by openapi generator's task. 
Currently failing for `:service_instance_tasks`
