### PR TITLE
Skip Inventories that were sent more than ENV['PERSISTER_TIMEOUT'] ago

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -357,6 +357,9 @@ class OpenapiGenerator
           :type   => "string",
           :format => "date-time"
         },
+        :refresh_type            => {
+          :type => "string"
+        },
         :sweep_scope             => {
           :oneOf => [
             {

--- a/lib/topological_inventory/persister/metrics.rb
+++ b/lib/topological_inventory/persister/metrics.rb
@@ -15,7 +15,15 @@ module TopologicalInventory
       end
 
       def record_process(success = true)
-        @process_counter&.observe(1, :result => success ? "success" : "error")
+        @process_counter&.observe(1, :result => case success
+                                                when true
+                                                  "success"
+                                                when false
+                                                  "error"
+                                                when :skipped
+                                                  "skipped"
+                                                end
+        )
       end
 
       def record_process_timing


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/66

defaulting to 60 minutes.

e2e-deploy: https://github.com/RedHatInsights/e2e-deploy/pull/2089

\# TODO:
- [x] specs
- [x] metric so we can alert if it starts happening a lot. 