### PR TITLE
Reduce output-stream payloads only to VMS

### DIFF
--- a/spec/persister/collections_spec.rb
+++ b/spec/persister/collections_spec.rb
@@ -23,201 +23,212 @@ describe TopologicalInventory::Persister::Worker do
     before do
       allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
       allow(client).to receive(:close)
-
-      # There should be 1 publish call writing to persister-output-stream queue
-      expect(client).to receive(:publish_message).exactly(1).times
     end
 
-    it "refreshes service_instances" do
-      refresh(client, ["collections", "service_instances.json"])
+    context "with sending to output-stream queue" do
+      before do
+        # There should be 1 publish call writing to persister-output-stream queue
+        expect(client).to receive(:publish_message).exactly(1).times
+      end
 
-      expect(source.service_instances.count).to eq(3)
+      it "refreshes vms" do
+        refresh(client, ["collections", "vms.json"])
 
-      service_instance = source.service_instances.find_by(:source_ref => "82e98be9-41bf-11e9-828d-0a580a8000cc")
-      service_plan     = source.service_plans.find_by(:source_ref => "836cc3e0-fdee-11e8-860c-06945c5af756")
-      service_offering = source.service_offerings.find_by(:source_ref => "836cc3e0-fdee-11e8-860c-06945c5af756")
+        expect(source.vms.count).to eq(6)
 
-      expect(service_instance).to(
-        have_attributes(
-          :tenant_id           => source.tenant_id,
-          :source_id           => source.id,
-          :source_ref          => "82e98be9-41bf-11e9-828d-0a580a8000cc",
-          :name                => "amq62-basic-07f3e100-366a-41d5-afd8-7e3d7a90c5d4",
-          :service_plan_id     => service_plan.id,
-          :service_offering_id => service_offering.id,
-          :external_url        => "https://test_openshift.com:8443/console/project/default/browse/service-instances/amq62-basic-07f3e100-366a-41d5-afd8-7e3d7a90c5d4?tab=details"
+        vm = source.vms.find_by(:source_ref => "i-8b5739f2")
+        expect(vm).to(
+          have_attributes(
+            :tenant_id   => source.tenant_id,
+            :source_id   => source.id,
+            :source_ref  => "i-8b5739f2",
+            :uid_ems     => "i-8b5739f2",
+            :name        => "EmsRefreshSpec-PoweredOn-VPC",
+            :power_state => "on"
+          )
         )
-      )
+
+        expect(vm.flavor).to(
+          have_attributes(
+            :tenant_id  => source.tenant_id,
+            :source_id  => source.id,
+            :source_ref => "t1.micro",
+            :name       => nil
+          )
+        )
+      end
+
+      it "refreshes volumes" do
+        refresh(client, ["collections", "volumes.json"])
+
+        expect(source.volumes.count).to eq(10)
+
+        volume = source.volumes.find_by(:source_ref => "vol-67606d2d")
+        expect(volume).to(
+          have_attributes(
+            :tenant_id         => source.tenant_id,
+            :source_id         => source.id,
+            :source_ref        => "vol-67606d2d",
+            :name              => "EmsRefreshSpec-PoweredOn-VPC-root",
+            :state             => "in-use",
+            :size              => 7_516_192_768,
+            :source_created_at => Time.parse("2013-09-23 20:11:57 UTC").utc
+          )
+        )
+
+        expect(volume.source_region).to(
+          have_attributes(
+            :tenant_id  => source.tenant_id,
+            :source_id  => source.id,
+            :source_ref => "us-east-1",
+            :name       => nil,
+            :endpoint   => nil
+          )
+        )
+
+        expect(volume.volume_type).to(
+          have_attributes(
+            :tenant_id   => source.tenant_id,
+            :source_id   => source.id,
+            :source_ref  => "standard",
+            :name        => nil,
+            :description => nil
+          )
+        )
+
+        expect(volume.volume_attachments.count).to eq(1)
+        expect(volume.volume_attachments.first).to(
+          have_attributes(
+            :tenant_id => source.tenant_id,
+            :device    => "/dev/sda1",
+            :state     => "attached"
+          )
+        )
+
+        expect(volume.vms.count).to eq(1)
+
+        expect(volume.vms.first).to(
+          have_attributes(
+            :tenant_id   => source.tenant_id,
+            :source_id   => source.id,
+            :source_ref  => "i-8b5739f2",
+            :uid_ems     => nil,
+            :name        => nil,
+            :power_state => nil
+          )
+        )
+      end
     end
 
-    it "refreshes container_resource_quotas" do
-      refresh(client, ["collections", "container_resource_quotas.json"])
+    context "without sending to output-stream queue" do
+      before do
+        # There should be 0 publish call writing to persister-output-stream queue
+        expect(client).to receive(:publish_message).exactly(0).times
+      end
 
-      expect(source.container_resource_quotas.count).to eq(3)
+      it "refreshes service_instances" do
+        refresh(client, ["collections", "service_instances.json"])
 
-      container_resource_quota = source.container_resource_quotas.find_by(:source_ref => "807d6b84-f691-11e7-9bd4-0a46c474dfe0")
-      expect(container_resource_quota).to(
-        have_attributes(
-          :tenant_id            => source.tenant_id,
-          :source_id            => source.id,
-          :container_project_id => nil,
-          :source_ref           => "807d6b84-f691-11e7-9bd4-0a46c474dfe0",
-          :resource_version     => "150282475",
-          :name                 => "compute-resources",
-          :status               => {
-            "hard" => {"limits.cpu" => "2", "limits.memory" => "1Gi"},
-            "used" => {"limits.cpu" => "0", "limits.memory" => "0"}
-          },
-          :spec                 => {
-            "hard"   => {"limits.cpu" => "2", "limits.memory" => "1Gi"},
-            "scopes" => ["NotTerminating"]
-          },
+        expect(source.service_instances.count).to eq(3)
+
+        service_instance = source.service_instances.find_by(:source_ref => "82e98be9-41bf-11e9-828d-0a580a8000cc")
+        service_plan     = source.service_plans.find_by(:source_ref => "836cc3e0-fdee-11e8-860c-06945c5af756")
+        service_offering = source.service_offerings.find_by(:source_ref => "836cc3e0-fdee-11e8-860c-06945c5af756")
+
+        expect(service_instance).to(
+          have_attributes(
+            :tenant_id           => source.tenant_id,
+            :source_id           => source.id,
+            :source_ref          => "82e98be9-41bf-11e9-828d-0a580a8000cc",
+            :name                => "amq62-basic-07f3e100-366a-41d5-afd8-7e3d7a90c5d4",
+            :service_plan_id     => service_plan.id,
+            :service_offering_id => service_offering.id,
+            :external_url        => "https://test_openshift.com:8443/console/project/default/browse/service-instances/amq62-basic-07f3e100-366a-41d5-afd8-7e3d7a90c5d4?tab=details"
+          )
         )
-      )
-    end
+      end
 
-    it "refreshes flavors" do
-      refresh(client, ["collections", "flavors.json"])
+      it "refreshes container_resource_quotas" do
+        refresh(client, ["collections", "container_resource_quotas.json"])
 
-      expect(source.flavors.count).to eq(164)
+        expect(source.container_resource_quotas.count).to eq(3)
 
-      flavor = source.flavors.find_by(:source_ref => "m1.small")
-      expect(flavor).to(
-        have_attributes(
-          :tenant_id  => source.tenant_id,
-          :source_id  => source.id,
-          :source_ref => "m1.small",
-          :name       => "m1.small"
+        container_resource_quota = source.container_resource_quotas.find_by(:source_ref => "807d6b84-f691-11e7-9bd4-0a46c474dfe0")
+        expect(container_resource_quota).to(
+          have_attributes(
+            :tenant_id            => source.tenant_id,
+            :source_id            => source.id,
+            :container_project_id => nil,
+            :source_ref           => "807d6b84-f691-11e7-9bd4-0a46c474dfe0",
+            :resource_version     => "150282475",
+            :name                 => "compute-resources",
+            :status               => {
+              "hard" => {"limits.cpu" => "2", "limits.memory" => "1Gi"},
+              "used" => {"limits.cpu" => "0", "limits.memory" => "0"}
+            },
+            :spec                 => {
+              "hard"   => {"limits.cpu" => "2", "limits.memory" => "1Gi"},
+              "scopes" => ["NotTerminating"]
+            }
+          )
         )
-      )
-    end
+      end
 
-    it "refreshes source_regions" do
-      refresh(client, ["collections", "source_regions.json"])
+      it "refreshes flavors" do
+        refresh(client, ["collections", "flavors.json"])
 
-      expect(source.source_regions.count).to eq(15)
+        expect(source.flavors.count).to eq(164)
 
-      source_region = source.source_regions.find_by(:source_ref => "us-east-1")
-      expect(source_region).to(
-        have_attributes(
-          :tenant_id  => source.tenant_id,
-          :source_id  => source.id,
-          :source_ref => "us-east-1",
-          :name       => "us-east-1",
-          :endpoint   => "ec2.us-east-1.amazonaws.com"
+        flavor = source.flavors.find_by(:source_ref => "m1.small")
+        expect(flavor).to(
+          have_attributes(
+            :tenant_id  => source.tenant_id,
+            :source_id  => source.id,
+            :source_ref => "m1.small",
+            :name       => "m1.small"
+          )
         )
-      )
-    end
+      end
 
-    it "refreshes vms" do
-      refresh(client, ["collections", "vms.json"])
+      it "refreshes source_regions" do
+        refresh(client, ["collections", "source_regions.json"])
 
-      expect(source.vms.count).to eq(6)
+        expect(source.source_regions.count).to eq(15)
 
-      vm = source.vms.find_by(:source_ref => "i-8b5739f2")
-      expect(vm).to(
-        have_attributes(
-          :tenant_id   => source.tenant_id,
-          :source_id   => source.id,
-          :source_ref  => "i-8b5739f2",
-          :uid_ems     => "i-8b5739f2",
-          :name        => "EmsRefreshSpec-PoweredOn-VPC",
-          :power_state => "on",
+        source_region = source.source_regions.find_by(:source_ref => "us-east-1")
+        expect(source_region).to(
+          have_attributes(
+            :tenant_id  => source.tenant_id,
+            :source_id  => source.id,
+            :source_ref => "us-east-1",
+            :name       => "us-east-1",
+            :endpoint   => "ec2.us-east-1.amazonaws.com"
+          )
         )
-      )
+      end
 
-      expect(vm.flavor).to(
-        have_attributes(
-          :tenant_id  => source.tenant_id,
-          :source_id  => source.id,
-          :source_ref => "t1.micro",
-          :name       => nil
+      it "refreshes volume_types" do
+        refresh(client, ["collections", "volume_types.json"])
+
+        expect(source.volume_types.count).to eq(5)
+
+        volume_type = source.volume_types.find_by(:source_ref => "gp2")
+        expect(volume_type).to(
+          have_attributes(
+            :tenant_id   => source.tenant_id,
+            :source_id   => source.id,
+            :source_ref  => "gp2",
+            :name        => "gp2",
+            :description => "General Purpose",
+            :extra       => {
+              "storageMedia"  => "SSD-backed",
+              "volumeType"    => "General Purpose",
+              "maxIopsvolume" => "10000",
+              "maxVolumeSize" => "16 TiB"
+            }
+          )
         )
-      )
-    end
-
-    it "refreshes volume_types" do
-      refresh(client, ["collections", "volume_types.json"])
-
-      expect(source.volume_types.count).to eq(5)
-
-      volume_type = source.volume_types.find_by(:source_ref => "gp2")
-      expect(volume_type).to(
-        have_attributes(
-          :tenant_id   => source.tenant_id,
-          :source_id   => source.id,
-          :source_ref  => "gp2",
-          :name        => "gp2",
-          :description => "General Purpose",
-          :extra       => {
-            "storageMedia"  => "SSD-backed",
-            "volumeType"    => "General Purpose",
-            "maxIopsvolume" => "10000",
-            "maxVolumeSize" => "16 TiB"
-          }
-        )
-      )
-    end
-
-    it "refreshes volumes" do
-      refresh(client, ["collections", "volumes.json"])
-
-      expect(source.volumes.count).to eq(10)
-
-      volume = source.volumes.find_by(:source_ref => "vol-67606d2d")
-      expect(volume).to(
-        have_attributes(
-          :tenant_id         => source.tenant_id,
-          :source_id         => source.id,
-          :source_ref        => "vol-67606d2d",
-          :name              => "EmsRefreshSpec-PoweredOn-VPC-root",
-          :state             => "in-use",
-          :size              => 7516192768,
-          :source_created_at => Time.parse("2013-09-23 20:11:57 UTC").utc,
-        )
-      )
-
-      expect(volume.source_region).to(
-        have_attributes(
-          :tenant_id  => source.tenant_id,
-          :source_id  => source.id,
-          :source_ref => "us-east-1",
-          :name       => nil,
-          :endpoint   => nil
-        )
-      )
-
-      expect(volume.volume_type).to(
-        have_attributes(
-          :tenant_id   => source.tenant_id,
-          :source_id   => source.id,
-          :source_ref  => "standard",
-          :name        => nil,
-          :description => nil
-        )
-      )
-
-      expect(volume.volume_attachments.count).to eq(1)
-      expect(volume.volume_attachments.first).to(
-        have_attributes(
-          :tenant_id => source.tenant_id,
-          :device    => "/dev/sda1",
-          :state     => "attached"
-        )
-      )
-
-      expect(volume.vms.count).to eq(1)
-
-      expect(volume.vms.first).to(
-        have_attributes(
-          :tenant_id   => source.tenant_id,
-          :source_id   => source.id,
-          :source_ref  => "i-8b5739f2",
-          :uid_ems     => nil,
-          :name        => nil,
-          :power_state => nil,
-        )
-      )
+      end
     end
   end
 end

--- a/spec/persister/mark_and_sweep_spec.rb
+++ b/spec/persister/mark_and_sweep_spec.rb
@@ -28,7 +28,7 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "automatically fills :last_seen_at timestamp for refreshed entities and archives them in last step" do
-      expect(client).to receive(:publish_message).exactly(2).times
+      expect(client).not_to receive(:publish_message)
 
       time_now = Time.now.utc
       time_before = Time.now.utc - 20.seconds
@@ -85,7 +85,7 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "sweeps only inventory_collections listed in persister's :sweep_scope" do
-      expect(client).to receive(:publish_message).exactly(2).times
+      expect(client).not_to receive(:publish_message)
 
       time_now = Time.now.utc
       time_before = Time.now.utc - 20.seconds
@@ -145,7 +145,7 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "sweeps subcollections with full scope" do
-      expect(client).to receive(:publish_message).exactly(2).times
+      expect(client).not_to receive(:publish_message)
 
       time_now = Time.now.utc
       time_before = Time.now.utc - 20.seconds
@@ -204,7 +204,7 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "sweeps subcollections with targeted scope" do
-      expect(client).to receive(:publish_message).exactly(2).times
+      expect(client).not_to receive(:publish_message)
 
       time_now = Time.now.utc
       time_before = Time.now.utc - 20.seconds
@@ -264,7 +264,7 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "checks partial update failure will error out the whole refresh_state" do
-      expect(client).to receive(:publish_message).exactly(1).times
+      expect(client).not_to receive(:publish_message)
 
       allow(TopologicalInventory::Persister).to receive(:logger).and_return(::InventoryRefresh::NullLogger.new)
 
@@ -309,7 +309,7 @@ describe TopologicalInventory::Persister::Worker do
 
     context "with empty scope" do
       before :each do
-        expect(client).to receive(:publish_message).exactly(2).times
+        expect(client).not_to receive(:publish_message)
         allow(TopologicalInventory::Persister).to receive(:logger).and_return(::InventoryRefresh::NullLogger.new)
 
         refresh(client, ["mark_and_sweep", "mark_part_1.json"])
@@ -369,7 +369,7 @@ describe TopologicalInventory::Persister::Worker do
       it "checks bad array format" do
         pending("Persister deserialization is not part of the workflow, therefore it fails a level up")
 
-        expect(client).to receive(:publish_message).exactly(2).times
+        expect(client).not_to receive(:publish_message)
         allow(TopologicalInventory::Persister).to receive(:logger).and_return(::InventoryRefresh::NullLogger.new)
 
         refresh(client, ["mark_and_sweep", "mark_part_1.json"])
@@ -387,7 +387,7 @@ describe TopologicalInventory::Persister::Worker do
       it "checks bad hash format" do
         pending("Persister deserialization is not part of the workflow, therefore it fails a level up")
 
-        expect(client).to receive(:publish_message).exactly(2).times
+        expect(client).not_to receive(:publish_message)
         allow(TopologicalInventory::Persister).to receive(:logger).and_return(::InventoryRefresh::NullLogger.new)
 
         refresh(client, ["mark_and_sweep", "mark_part_1.json"])
@@ -405,7 +405,7 @@ describe TopologicalInventory::Persister::Worker do
       it "checks bad string format" do
         pending("Persister deserialization is not part of the workflow, therefore it fails a level up")
 
-        expect(client).to receive(:publish_message).exactly(2).times
+        expect(client).not_to receive(:publish_message)
         allow(TopologicalInventory::Persister).to receive(:logger).and_return(::InventoryRefresh::NullLogger.new)
 
         refresh(client, ["mark_and_sweep", "mark_part_1.json"])
@@ -472,7 +472,7 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "checks sweeping doesn't fail when we remove the refresh state" do
-      expect(client).to receive(:publish_message).exactly(3).times
+      expect(client).to receive(:publish_message).exactly(1).times # requeue sweeping
 
       # Refresh first and second part and mark :last_seen_at
       refresh(client, ["mark_and_sweep", "mark_part_1.json"])


### PR DESCRIPTION
Persister is sending all changes to persister-output-stream topic. 

But nobody except host-inventory-sync service is using it (checked on CI's kafka lag), so we are creating huge useless streaming

---

[TPINVTRY-1044](https://projects.engineering.redhat.com/browse/TPINVTRY-1044)