### PR TITLE
Set spec port to 0 everywhere we do not need the metrics server

### DIFF
--- a/spec/persister/refresh_worker_helper.rb
+++ b/spec/persister/refresh_worker_helper.rb
@@ -6,7 +6,7 @@ module TestInventory
 
       allow(client).to receive(:subscribe_topic).and_yield(message)
 
-      described_class.new(:metrics_port => 9394).run
+      described_class.new(:metrics_port => 0).run
       source.reload
     end
   end


### PR DESCRIPTION
This will (hopefully) prevent the intermittent spec failures we see every so often on this repo. 
