### PR TITLE
Add heartbeat check after message process

### DIFF
--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -68,6 +68,8 @@ module TopologicalInventory
         nil
       else
         metrics.record_process
+      ensure
+        touch_heartbeat
       end
 
       def log_err_and_send_metric(e)
@@ -119,6 +121,10 @@ module TopologicalInventory
 
       def timeout
         (ENV['PERSISTER_TIMEOUT']&.to_i || 60).minutes.ago
+      end
+
+      def touch_heartbeat
+        FileUtils.touch("/tmp/healthy")
       end
     end
   end


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-9485

Simple PR to add a heartbeat touch after message process. I would use the `providers-common` class - but it doesn't quite make sense to pull in that gem for something that just runs `FileUtils.touch`

