### PR TITLE
Custom metrics

### DIFF
--- a/lib/topological_inventory/persister/metrics.rb
+++ b/lib/topological_inventory/persister/metrics.rb
@@ -14,16 +14,10 @@ module TopologicalInventory
         configure_metrics
       end
 
-      def record_process(success = true)
-        @process_counter&.observe(1, :result => case success
-                                                when true
-                                                  "success"
-                                                when false
-                                                  "error"
-                                                when :skipped
-                                                  "skipped"
-                                                end
-        )
+      # @param status [Symbol] - :success, :error, :skipped, :requeued
+      # @param labels [Hash] - keys == :error_class,
+      def record_process(status = :success, labels = {})
+        @process_counter&.observe(1, labels.merge(:result => status.to_s))
       end
 
       def record_process_timing

--- a/spec/persister/metrics_spec.rb
+++ b/spec/persister/metrics_spec.rb
@@ -8,7 +8,7 @@ describe TopologicalInventory::Persister::Metrics do
   it "exposes metrics" do
     subject.record_process
     subject.record_process
-    subject.record_process false
+    subject.record_process(:error)
     subject.record_process_timing { }
 
     metrics = get_metrics


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

Labels extension to current metrics `topological_inventory_persister_`:
- messages_total
- message_process_seconds

---

[RHCLOUD-9943](https://issues.redhat.com/browse/RHCLOUD-9943)