### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Short description and motivation.
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-persister.svg)](https://travis-ci.org/RedHatInsights/topological_inventory-persister)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-persister.svg)](https://travis-ci.com/RedHatInsights/topological_inventory-persister)
 [![Maintainability](https://api.codeclimate.com/v1/badges/1b3b144efe20144d96e1/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-persister/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/1b3b144efe20144d96e1/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-persister/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/topological_inventory-persister/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-persister/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.