### PR TITLE
Fix of docker image building (mimemagic)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
       postgresql-devel libxml2-devel \
       # For the rdkafka gem
       cyrus-sasl-devel zlib-devel openssl-devel diffutils \
+      # For the mimemagic gem
+      shared-mime-info \
       && \
       dnf --disableplugin=subscription-manager clean all
 


### PR DESCRIPTION
mimemagic gem requires shared-mime-types database installed on the system (part of rails)

---

https://github.com/RedHatInsights/topological_inventory-api/issues/353

[RHCLOUD-13462](https://issues.redhat.com/browse/RHCLOUD-13462)